### PR TITLE
Fix dev server startup by adding Vite alias config

### DIFF
--- a/poker-ranking-app/vite.config.js
+++ b/poker-ranking-app/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add missing `vite.config.js` so imports using `@/` resolve correctly

## Testing
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68838fdbd578832f83e0182b778e2fbe